### PR TITLE
fix: コードの堅牢性を向上（型安全・null安全・タイムアウト対応）

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -189,7 +189,9 @@ class _AuthWrapperState extends State<AuthWrapper> {
         // エラー発生時もサインアウト
         try {
           await SupabaseService.instance.signOut();
-        } catch (_) {}
+        } catch (signOutError) {
+          debugPrint('⚠️ Sign out failed during error recovery: $signOutError');
+        }
         setState(() {
           _isVerifyingGuild = false;
           _guildVerified = false;

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -104,10 +104,11 @@ class _HomeScreenState extends State<HomeScreen> {
           .select('*')
           .order('created_at', ascending: false);
 
-      final videosData = response as List<dynamic>;
+      final videosData = response is List<dynamic> ? response : <dynamic>[];
 
       // 各動画のユーザーIDを収集（重複を除く）
       final userIds = videosData
+          .whereType<Map<String, dynamic>>()
           .map((v) => v['user_id'] as String?)
           .where((id) => id != null && id.isNotEmpty)
           .toSet()
@@ -121,15 +122,22 @@ class _HomeScreenState extends State<HomeScreen> {
             .select('*')
             .inFilter('id', userIds);
 
-        for (final profile in (profilesResponse as List)) {
-          profilesMap[profile['id'] as String] = profile;
+        for (final profile in (profilesResponse is List ? profilesResponse : <dynamic>[])) {
+          if (profile is Map<String, dynamic>) {
+            final id = profile['id'] as String?;
+            if (id != null) profilesMap[id] = profile;
+          }
         }
       }
 
       // 各動画のタグ情報を取得
       Map<String, List<String>> videoTagsMap = {};
       if (videosData.isNotEmpty) {
-        final videoIds = videosData.map((v) => v['id'] as String).toList();
+        final videoIds = videosData
+            .whereType<Map<String, dynamic>>()
+            .map((v) => v['id'] as String? ?? '')
+            .where((id) => id.isNotEmpty)
+            .toList();
 
         // video_tagsテーブルとtagsテーブルをJOINして取得
         final tagsResponse = await _supabase
@@ -137,9 +145,13 @@ class _HomeScreenState extends State<HomeScreen> {
             .select('video_id, tags!inner(name)')
             .inFilter('video_id', videoIds);
 
-        for (final item in (tagsResponse as List)) {
-          final videoId = item['video_id'] as String;
-          final tagName = item['tags']['name'] as String;
+        for (final item in (tagsResponse is List ? tagsResponse : <dynamic>[])) {
+          if (item is! Map<String, dynamic>) continue;
+          final videoId = item['video_id'] as String? ?? '';
+          final tagName = item['tags'] is Map
+              ? (item['tags'] as Map)['name'] as String? ?? ''
+              : '';
+          if (videoId.isEmpty || tagName.isEmpty) continue;
 
           if (!videoTagsMap.containsKey(videoId)) {
             videoTagsMap[videoId] = [];
@@ -149,22 +161,20 @@ class _HomeScreenState extends State<HomeScreen> {
       }
 
       // 動画データとプロフィール情報、タグ情報を結合
-      final videos = videosData.map((videoJson) {
-        final userId = videoJson['user_id'] as String?;
-        if (userId != null && profilesMap.containsKey(userId)) {
-          videoJson['profiles'] = profilesMap[userId];
-        }
+      final videos = videosData
+          .whereType<Map<String, dynamic>>()
+          .map((videoJson) {
+            final userId = videoJson['user_id'] as String?;
+            if (userId != null && profilesMap.containsKey(userId)) {
+              videoJson['profiles'] = profilesMap[userId];
+            }
 
-        // タグ情報を追加
-        final videoId = videoJson['id'] as String;
-        if (videoTagsMap.containsKey(videoId)) {
-          videoJson['tags'] = videoTagsMap[videoId];
-        } else {
-          videoJson['tags'] = [];
-        }
+            // タグ情報を追加
+            final videoId = videoJson['id'] as String? ?? '';
+            videoJson['tags'] = videoTagsMap[videoId] ?? [];
 
-        return Video.fromJsonWithProfile(videoJson as Map<String, dynamic>);
-      })
+            return Video.fromJsonWithProfile(videoJson);
+          })
           .where((video) => video.id.isNotEmpty)
           .toList();
 

--- a/lib/screens/subscriptions/subscriptions_screen.dart
+++ b/lib/screens/subscriptions/subscriptions_screen.dart
@@ -101,8 +101,9 @@ class _SubscriptionsScreenState extends State<SubscriptionsScreen> {
           .select('*')
           .inFilter('id', channelIds);
 
-      final channels = (profilesResponse as List)
-          .map((p) => UserProfile.fromJson(p as Map<String, dynamic>))
+      final channels = (profilesResponse is List ? profilesResponse : <dynamic>[])
+          .whereType<Map<String, dynamic>>()
+          .map((p) => UserProfile.fromJson(p))
           .toList();
 
       // キャッシュに保存（チャンネル一覧）
@@ -158,10 +159,13 @@ class _SubscriptionsScreenState extends State<SubscriptionsScreen> {
           .inFilter('user_id', targetChannelIds)
           .order('created_at', ascending: false);
 
-      final videosData = videosResponse as List<dynamic>;
+      final videosData = videosResponse is List<dynamic>
+          ? videosResponse
+          : <dynamic>[];
       
       // 各動画のユーザーIDを収集（重複を除く）
       final userIds = videosData
+          .whereType<Map<String, dynamic>>()
           .map((v) => v['user_id'] as String?)
           .where((id) => id != null && id.isNotEmpty)
           .toSet()
@@ -175,22 +179,26 @@ class _SubscriptionsScreenState extends State<SubscriptionsScreen> {
             .select('*')
             .inFilter('id', userIds);
 
-        for (final profile in (profilesResponse as List)) {
-          profilesMap[profile['id'] as String] = profile;
+        for (final profile in (profilesResponse is List ? profilesResponse : <dynamic>[])) {
+          if (profile is Map<String, dynamic>) {
+            final id = profile['id'] as String?;
+            if (id != null) profilesMap[id] = profile;
+          }
         }
       }
 
       // 動画データとプロフィール情報を結合
-      final videos = videosData.map((videoJson) {
-        final userId = videoJson['user_id'] as String?;
-        if (userId != null && profilesMap.containsKey(userId)) {
-          videoJson['profiles'] = profilesMap[userId];
-        }
-        
-        return Video.fromJsonWithProfile(videoJson as Map<String, dynamic>);
-      })
-      .where((video) => video.id.isNotEmpty)
-      .toList();
+      final videos = videosData
+          .whereType<Map<String, dynamic>>()
+          .map((videoJson) {
+            final userId = videoJson['user_id'] as String?;
+            if (userId != null && profilesMap.containsKey(userId)) {
+              videoJson['profiles'] = profilesMap[userId];
+            }
+            return Video.fromJsonWithProfile(videoJson);
+          })
+          .where((video) => video.id.isNotEmpty)
+          .toList();
 
       // キャッシュに保存（動画一覧）
       CacheService.instance.set<List<Video>>(CacheKeys.subscriptionVideos, videos);

--- a/lib/screens/timeline/timeline_screen.dart
+++ b/lib/screens/timeline/timeline_screen.dart
@@ -62,9 +62,10 @@ class _TimelineScreenState extends State<TimelineScreen> {
     // 現在見えているセクションを特定（簡易実装）
     for (final key in _sortedMonthKeys) {
       final globalKey = _sectionKeys[key];
-      if (globalKey?.currentContext == null) continue;
+      final context = globalKey?.currentContext;
+      if (context == null) continue;
 
-      final renderBox = globalKey!.currentContext!.findRenderObject() as RenderBox?;
+      final renderBox = context.findRenderObject() as RenderBox?;
       if (renderBox == null) continue;
 
       final position = renderBox.localToGlobal(Offset.zero);
@@ -118,10 +119,11 @@ class _TimelineScreenState extends State<TimelineScreen> {
           .select('*')
           .order('created_at', ascending: false);
 
-      final videosData = response as List<dynamic>;
+      final videosData = response is List<dynamic> ? response : <dynamic>[];
 
       // プロフィール情報を一括取得
       final userIds = videosData
+          .whereType<Map<String, dynamic>>()
           .map((v) => v['user_id'] as String?)
           .where((id) => id != null && id.isNotEmpty)
           .toSet()
@@ -133,20 +135,27 @@ class _TimelineScreenState extends State<TimelineScreen> {
             .from('profiles')
             .select('*')
             .inFilter('id', userIds);
-        for (final profile in (profilesResponse as List)) {
-          profilesMap[profile['id'] as String] = profile;
+        for (final profile in (profilesResponse is List ? profilesResponse : <dynamic>[])) {
+          if (profile is Map<String, dynamic>) {
+            final id = profile['id'] as String?;
+            if (id != null) profilesMap[id] = profile;
+          }
         }
       }
 
       // 動画オブジェクトを生成
-      final videos = videosData.map((videoJson) {
-        final userId = videoJson['user_id'] as String?;
-        if (userId != null && profilesMap.containsKey(userId)) {
-          videoJson['profiles'] = profilesMap[userId];
-        }
-        videoJson['tags'] = [];
-        return Video.fromJsonWithProfile(videoJson as Map<String, dynamic>);
-      }).where((v) => v.id.isNotEmpty).toList();
+      final videos = videosData
+          .whereType<Map<String, dynamic>>()
+          .map((videoJson) {
+            final userId = videoJson['user_id'] as String?;
+            if (userId != null && profilesMap.containsKey(userId)) {
+              videoJson['profiles'] = profilesMap[userId];
+            }
+            videoJson['tags'] = [];
+            return Video.fromJsonWithProfile(videoJson);
+          })
+          .where((v) => v.id.isNotEmpty)
+          .toList();
 
       // 年月でグループ化
       final grouped = <String, List<Video>>{};

--- a/lib/services/discord_auth_service.dart
+++ b/lib/services/discord_auth_service.dart
@@ -122,13 +122,15 @@ class DiscordAuthService {
       }
 
       // Discord APIでユーザーのギルド一覧を取得
-      final response = await http.get(
-        Uri.parse('https://discord.com/api/v10/users/@me/guilds'),
-        headers: {
-          'Authorization': 'Bearer $providerToken',
-          'Content-Type': 'application/json',
-        },
-      );
+      final response = await http
+          .get(
+            Uri.parse('https://discord.com/api/v10/users/@me/guilds'),
+            headers: {
+              'Authorization': 'Bearer $providerToken',
+              'Content-Type': 'application/json',
+            },
+          )
+          .timeout(const Duration(seconds: 10));
 
       if (response.statusCode != 200) {
         if (kDebugMode) {
@@ -253,7 +255,11 @@ class DiscordAuthService {
       // エラーが発生した場合もサインアウト
       try {
         await SupabaseService.instance.signOut();
-      } catch (_) {}
+      } catch (signOutError) {
+        if (kDebugMode) {
+          debugPrint('⚠️ Sign out failed during error recovery: $signOutError');
+        }
+      }
       rethrow;
     }
   }

--- a/lib/services/playlist_service.dart
+++ b/lib/services/playlist_service.dart
@@ -1,6 +1,8 @@
 /// プレイリスト関連のSupabase操作サービス
 library;
 
+import 'package:flutter/foundation.dart';
+
 import '../models/playlist.dart';
 import '../models/video.dart';
 import 'supabase_service.dart';
@@ -25,8 +27,9 @@ class PlaylistService {
         .eq('user_id', userId)
         .order('created_at', ascending: false);
 
-    final playlists = (playlistsResponse as List)
-        .map((p) => Playlist.fromJson(p as Map<String, dynamic>))
+    final playlists = (playlistsResponse is List ? playlistsResponse : <dynamic>[])
+        .whereType<Map<String, dynamic>>()
+        .map((p) => Playlist.fromJson(p))
         .toList();
 
     if (playlists.isEmpty) return [];
@@ -41,9 +44,11 @@ class PlaylistService {
 
     // playlist_id ごとに動画を集める
     final Map<String, List<Map<String, dynamic>>> pvMap = {};
-    for (final row in (pvResponse as List)) {
-      final pid = row['playlist_id'] as String;
-      pvMap.putIfAbsent(pid, () => []).add(row as Map<String, dynamic>);
+    for (final row in (pvResponse is List ? pvResponse : <dynamic>[])) {
+      if (row is! Map<String, dynamic>) continue;
+      final pid = row['playlist_id'] as String? ?? '';
+      if (pid.isEmpty) continue;
+      pvMap.putIfAbsent(pid, () => []).add(row);
     }
 
     // 3) PlaylistWithMeta を組み立てる
@@ -84,8 +89,9 @@ class PlaylistService {
         .eq('user_id', currentUser.id)
         .order('created_at', ascending: false);
 
-    return (response as List)
-        .map((p) => Playlist.fromJson(p as Map<String, dynamic>))
+    return (response is List ? response : <dynamic>[])
+        .whereType<Map<String, dynamic>>()
+        .map((p) => Playlist.fromJson(p))
         .toList();
   }
 
@@ -100,8 +106,9 @@ class PlaylistService {
         .from('playlists')
         .insert({'user_id': currentUser.id, 'name': name.trim()})
         .select()
-        .single();
+        .maybeSingle();
 
+    if (response == null) throw Exception('プレイリストの作成に失敗しました');
     return Playlist.fromJson(response);
   }
 
@@ -121,7 +128,11 @@ class PlaylistService {
         .eq('video_id', videoId)
         .inFilter('playlist_id', myPlaylistIds);
 
-    return (response as List).map((r) => r['playlist_id'] as String).toList();
+    return (response is List ? response : <dynamic>[])
+        .whereType<Map<String, dynamic>>()
+        .map((r) => r['playlist_id'] as String? ?? '')
+        .where((id) => id.isNotEmpty)
+        .toList();
   }
 
   /// 動画のプレイリスト関連付けを一括更新する
@@ -165,7 +176,8 @@ class PlaylistService {
         .order('added_at', ascending: false);
 
     final List<Video> videos = [];
-    for (final row in (response as List)) {
+    for (final row in (response is List ? response : <dynamic>[])) {
+      if (row is! Map<String, dynamic>) continue;
       final videoJson = row['videos'] as Map<String, dynamic>?;
       if (videoJson == null) continue;
 
@@ -181,7 +193,9 @@ class PlaylistService {
           if (profileResponse != null) {
             videoJson['profiles'] = profileResponse;
           }
-        } catch (_) {}
+        } catch (e) {
+          debugPrint('⚠️ Failed to fetch profile for user $userId: $e');
+        }
       }
 
       // タグを取得
@@ -192,11 +206,13 @@ class PlaylistService {
               .from('video_tags')
               .select('tags!inner(name)')
               .eq('video_id', videoId);
-          videoJson['tags'] = (tagsResponse as List)
+          videoJson['tags'] = (tagsResponse is List ? tagsResponse : <dynamic>[])
+              .whereType<Map<String, dynamic>>()
               .map((t) => t['tags']?['name']?.toString() ?? '')
               .where((name) => name.isNotEmpty)
               .toList();
-        } catch (_) {
+        } catch (e) {
+          debugPrint('⚠️ Failed to fetch tags for video $videoId: $e');
           videoJson['tags'] = <String>[];
         }
       }

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -294,7 +294,9 @@ class SupabaseService {
       }
 
       // メールアドレスのローカル部分をデフォルトユーザー名として使用
-      String defaultUsername = user.email!.split('@')[0];
+      // emailがnullの場合（Discord OAuthなど）はuser IDの先頭8文字をフォールバックとして使用
+      String defaultUsername =
+          user.email?.split('@')[0] ?? 'user_${user.id.substring(0, 8)}';
 
       // ユーザー名が既に存在するかチェック
       final existingUsername = await client
@@ -525,7 +527,7 @@ class SupabaseService {
           .select()
           .eq('channel_id', channelId);
 
-      return (result as List).length;
+      return result is List ? result.length : 0;
     } catch (e) {
       if (kDebugMode) {
         debugPrint('❌ Failed to get subscriber count: $e');
@@ -549,7 +551,12 @@ class SupabaseService {
           .select('channel_id')
           .eq('subscriber_id', currentUserId);
 
-      return (result as List).map((e) => e['channel_id'] as String).toList();
+      if (result is! List) return [];
+      return result
+          .whereType<Map<String, dynamic>>()
+          .map((e) => e['channel_id'] as String? ?? '')
+          .where((id) => id.isNotEmpty)
+          .toList();
     } catch (e) {
       if (kDebugMode) {
         debugPrint('❌ Failed to get subscribed channel IDs: $e');
@@ -570,7 +577,7 @@ class SupabaseService {
           .select()
           .eq('user_id', channelId);
 
-      return (result as List).length;
+      return result is List ? result.length : 0;
     } catch (e) {
       if (kDebugMode) {
         debugPrint('❌ Failed to get channel video count: $e');

--- a/lib/services/youtube_service.dart
+++ b/lib/services/youtube_service.dart
@@ -276,7 +276,13 @@ class YouTubeService {
         debugPrint('🎬 Attempting to launch video: $url');
       }
 
-      final uri = Uri.parse(url.trim());
+      final uri = Uri.tryParse(url.trim());
+      if (uri == null) {
+        if (kDebugMode) {
+          debugPrint('⚠️ Invalid URL provided to launchVideo: $url');
+        }
+        return false;
+      }
 
       // URLが開けるかチェック
       if (!await canLaunchUrl(uri)) {


### PR DESCRIPTION
- supabase_service.dart: user.email! の強制アンラップを null-safe に修正（Discord OAuthなどemailがnullの場合のクラッシュ防止）
- supabase_service.dart: (result as List) の不安全なキャストを型チェックに変更
- playlist_service.dart: .single() を .maybeSingle() に変更し、nullの場合に明示的な例外をスロー
- playlist_service.dart: (response as List) の不安全なキャストを whereType<> パターンに変更
- discord_auth_service.dart: Discord API呼び出しに10秒のタイムアウトを追加
- discord_auth_service.dart / main.dart: catch (_) {} のサイレント例外を debugPrint でログ出力するよう修正
- youtube_service.dart: Uri.parse() を Uri.tryParse() に変更し、不正URLでのクラッシュを防止
- home_screen.dart / subscriptions_screen.dart / timeline_screen.dart: Supabaseレスポンスの不安全なキャストを型安全なパターンに変更
- timeline_screen.dart: チェーンされた強制アンラップ (globalKey!.currentContext!) を安全なnullチェックに修正

https://claude.ai/code/session_01Hz29aoneXTsfTSmru1kk6r