### PR TITLE
fix: use_build_context_synchronously in SearchBar onSubmitted handler

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -886,11 +886,11 @@ class _HomeScreenState extends State<HomeScreen> {
                       if (trimmed.isNotEmpty) {
                         await SearchHistoryService.instance.addSearchQuery(trimmed);
                       }
+                      if (!mounted) return;
                       if (controller.isOpen) {
                         controller.closeView(trimmed);
                       } else {
                         controller.text = trimmed;
-                        if (!context.mounted) return;
                         FocusScope.of(context).unfocus();
                       }
                       setState(() {


### PR DESCRIPTION
await後のcontextアクセスを守るmountedチェックがelseブランチ内のみで
不完全だった問題を修正。context.mountedをif/else分岐の前に移動し、
State.mountedを使う正しいパターン(if (!mounted) return;)に変更。

https://claude.ai/code/session_01QUC9FqTa4TSe2YwwQ4igp5