### PR TITLE
feat: アップデートインストール前の「提供元不明のアプリ」許可チェック・誘導機能を追加

### DIFF
--- a/android/app/src/main/kotlin/win/okasis/sabatube/MainActivity.kt
+++ b/android/app/src/main/kotlin/win/okasis/sabatube/MainActivity.kt
@@ -1,5 +1,39 @@
 package win.okasis.sabatube
 
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val CHANNEL = "win.okasis.sabatube/install_permission"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "canInstallPackages" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        result.success(packageManager.canRequestPackageInstalls())
+                    } else {
+                        // Android 8.0 未満は常に許可済みとみなす
+                        result.success(true)
+                    }
+                }
+                "openInstallPermissionSettings" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        val intent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                            data = Uri.parse("package:$packageName")
+                        }
+                        startActivity(intent)
+                    }
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/win/okasis/sabatube/MainActivity.kt
+++ b/android/app/src/main/kotlin/win/okasis/sabatube/MainActivity.kt
@@ -25,10 +25,15 @@ class MainActivity : FlutterActivity() {
                 }
                 "openInstallPermissionSettings" -> {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        val intent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
-                            data = Uri.parse("package:$packageName")
+                        try {
+                            val intent = Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                                data = Uri.parse("package:$packageName")
+                            }
+                            startActivity(intent)
+                        } catch (e: Exception) {
+                            result.error("SETTINGS_ERROR", e.message, null)
+                            return@setMethodCallHandler
                         }
-                        startActivity(intent)
                     }
                     result.success(null)
                 }

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -112,7 +112,7 @@ class AppUpdateService {
         return null;
       }
 
-      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final json = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
       final updateInfo = UpdateInfo.fromJson(json);
 
       // 現在のバージョンコードと比較

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 import 'package:open_file/open_file.dart';
@@ -46,11 +47,41 @@ class AppUpdateService {
   AppUpdateService._();
   static final AppUpdateService instance = AppUpdateService._();
 
+  static const _channel = MethodChannel('win.okasis.sabatube/install_permission');
+
   /// ダウンロード進捗 (0.0 〜 1.0)。UI側は ValueListenableBuilder でリッスンする。
   final ValueNotifier<double> downloadProgress = ValueNotifier(0.0);
 
   /// ダウンロード中かどうか
   final ValueNotifier<bool> isDownloading = ValueNotifier(false);
+
+  // ------------------------------------------------------------------
+  // インストール権限チェック
+  // ------------------------------------------------------------------
+
+  /// Android 8.0+ で「提供元不明のアプリ」インストール許可が付与されているか確認する。
+  ///
+  /// Android 8.0 未満や Android 以外のプラットフォームでは true を返す。
+  Future<bool> canInstallPackages() async {
+    if (kIsWeb || !Platform.isAndroid) return true;
+    try {
+      final result = await _channel.invokeMethod<bool>('canInstallPackages');
+      return result ?? true;
+    } catch (e) {
+      debugPrint('❌ AppUpdateService.canInstallPackages: $e');
+      return true;
+    }
+  }
+
+  /// Android の「提供元不明のアプリ」許可設定画面を開く。
+  Future<void> openInstallPermissionSettings() async {
+    if (kIsWeb || !Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod('openInstallPermissionSettings');
+    } catch (e) {
+      debugPrint('❌ AppUpdateService.openInstallPermissionSettings: $e');
+    }
+  }
 
   // ------------------------------------------------------------------
   // アップデート確認

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -74,12 +74,16 @@ class AppUpdateService {
   }
 
   /// Android の「提供元不明のアプリ」許可設定画面を開く。
-  Future<void> openInstallPermissionSettings() async {
-    if (kIsWeb || !Platform.isAndroid) return;
+  ///
+  /// 設定画面を開けなかった場合は false を返す。
+  Future<bool> openInstallPermissionSettings() async {
+    if (kIsWeb || !Platform.isAndroid) return false;
     try {
       await _channel.invokeMethod('openInstallPermissionSettings');
+      return true;
     } catch (e) {
       debugPrint('❌ AppUpdateService.openInstallPermissionSettings: $e');
+      return false;
     }
   }
 
@@ -160,24 +164,32 @@ class AppUpdateService {
         return null;
       }
 
+      // Content-Length が不明な場合は totalBytes == 0 → 進捗を null（不定）で表示
       final totalBytes = response.contentLength ?? 0;
       int receivedBytes = 0;
 
       final sink = file.openWrite();
-      await for (final chunk in response.stream) {
-        sink.add(chunk);
-        receivedBytes += chunk.length;
-        if (totalBytes > 0) {
-          downloadProgress.value = receivedBytes / totalBytes;
+      try {
+        await for (final chunk in response.stream) {
+          sink.add(chunk);
+          receivedBytes += chunk.length;
+          downloadProgress.value =
+              totalBytes > 0 ? receivedBytes / totalBytes : -1.0;
         }
+      } finally {
+        await sink.close();
       }
-      await sink.close();
 
       downloadProgress.value = 1.0;
       debugPrint('✅ AppUpdateService: APK ダウンロード完了 → $savePath');
       return savePath;
     } catch (e) {
       debugPrint('❌ AppUpdateService.downloadApk: $e');
+      // 中途半端なファイルが残らないよう削除する
+      try {
+        final partial = File('${(await getTemporaryDirectory()).path}/SabaTube_update.apk');
+        if (await partial.exists()) await partial.delete();
+      } catch (_) {}
       return null;
     } finally {
       isDownloading.value = false;

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -5,8 +5,9 @@ import '../services/app_update_service.dart';
 ///
 /// 状態遷移:
 ///   1. 初期表示: バージョン情報・リリースノートを表示
-///   2. ダウンロード中: プログレスバー表示（キャンセル不可）
-///   3. インストール準備完了: 「インストール」ボタン表示
+///   2. 権限未許可: 「提供元不明のアプリ」許可を求める画面
+///   3. ダウンロード中: プログレスバー表示（キャンセル不可）
+///   4. インストール準備完了: 「インストール」ボタン表示
 class UpdateDialog extends StatefulWidget {
   final UpdateInfo updateInfo;
 
@@ -25,14 +26,61 @@ class UpdateDialog extends StatefulWidget {
   State<UpdateDialog> createState() => _UpdateDialogState();
 }
 
-enum _UpdateStep { prompt, downloading, readyToInstall }
+enum _UpdateStep { prompt, permissionRequired, downloading, readyToInstall }
 
-class _UpdateDialogState extends State<UpdateDialog> {
+class _UpdateDialogState extends State<UpdateDialog> with WidgetsBindingObserver {
   _UpdateStep _step = _UpdateStep.prompt;
   String? _downloadedPath;
   String? _errorMessage;
 
   final _service = AppUpdateService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  /// 設定画面から戻ってきたときに権限を再チェックする。
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && _step == _UpdateStep.permissionRequired) {
+      _resumeAfterSettings();
+    }
+  }
+
+  Future<void> _resumeAfterSettings() async {
+    final granted = await _service.canInstallPackages();
+    if (!mounted) return;
+    if (granted) {
+      // 許可が付与されたのでダウンロードへ進む
+      setState(() => _errorMessage = null);
+      await _startDownload();
+    }
+    // まだ未許可なら permissionRequired のまま待機（何もしない）
+  }
+
+  /// アップデートボタン押下: 権限を確認してからダウンロード開始。
+  Future<void> _onUpdatePressed() async {
+    final granted = await _service.canInstallPackages();
+    if (!mounted) return;
+
+    if (!granted) {
+      setState(() {
+        _step = _UpdateStep.permissionRequired;
+        _errorMessage = null;
+      });
+      return;
+    }
+
+    await _startDownload();
+  }
 
   Future<void> _startDownload() async {
     setState(() {
@@ -59,13 +107,26 @@ class _UpdateDialogState extends State<UpdateDialog> {
 
   Future<void> _install() async {
     if (_downloadedPath == null) return;
+
+    // インストール直前にも権限を再確認
+    final granted = await _service.canInstallPackages();
+    if (!mounted) return;
+
+    if (!granted) {
+      setState(() {
+        _step = _UpdateStep.permissionRequired;
+        _errorMessage = null;
+      });
+      return;
+    }
+
     final success = await _service.installApk(_downloadedPath!);
     if (!mounted) return;
     if (success) {
       Navigator.of(context).pop();
     } else {
       setState(() {
-        _errorMessage = 'インストーラーの起動に失敗しました。\n「提供元不明のアプリ」の許可が必要な場合があります。';
+        _errorMessage = 'インストーラーの起動に失敗しました。もう一度お試しください。';
       });
     }
   }
@@ -79,10 +140,17 @@ class _UpdateDialogState extends State<UpdateDialog> {
         backgroundColor: const Color(0xFF272727),
         title: Row(
           children: [
-            const Icon(Icons.system_update, color: Color(0xFFF20D0D)),
+            Icon(
+              _step == _UpdateStep.permissionRequired
+                  ? Icons.security
+                  : Icons.system_update,
+              color: const Color(0xFFF20D0D),
+            ),
             const SizedBox(width: 8),
             Text(
-              'アップデートがあります',
+              _step == _UpdateStep.permissionRequired
+                  ? 'インストール許可が必要です'
+                  : 'アップデートがあります',
               style: const TextStyle(color: Colors.white, fontSize: 16),
             ),
           ],
@@ -94,6 +162,10 @@ class _UpdateDialogState extends State<UpdateDialog> {
   }
 
   Widget _buildContent() {
+    if (_step == _UpdateStep.permissionRequired) {
+      return _buildPermissionContent();
+    }
+
     return SizedBox(
       width: double.maxFinite,
       child: Column(
@@ -177,6 +249,61 @@ class _UpdateDialogState extends State<UpdateDialog> {
     );
   }
 
+  Widget _buildPermissionContent() {
+    return SizedBox(
+      width: double.maxFinite,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 説明テキスト
+          const Text(
+            'SabaTube のアップデートをインストールするには、「提供元不明のアプリ」のインストール許可が必要です。',
+            style: TextStyle(color: Colors.white, fontSize: 13),
+          ),
+          const SizedBox(height: 16),
+
+          // 手順
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: const Color(0xFF1A1A1A),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                Text(
+                  '許可の手順',
+                  style: TextStyle(
+                    color: Color(0xFFAAAAAA),
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                SizedBox(height: 6),
+                Text(
+                  '1. 下の「設定を開く」ボタンをタップ\n'
+                  '2.「この提供元のアプリを許可」をオン\n'
+                  '3. アプリに戻るとダウンロードが始まります',
+                  style: TextStyle(color: Color(0xFFCCCCCC), fontSize: 12, height: 1.6),
+                ),
+              ],
+            ),
+          ),
+
+          if (_errorMessage != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _errorMessage!,
+              style: const TextStyle(color: Color(0xFFFF5555), fontSize: 12),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   List<Widget> _buildActions() {
     if (_step == _UpdateStep.downloading) {
       return [
@@ -186,6 +313,24 @@ class _UpdateDialogState extends State<UpdateDialog> {
             'ダウンロードが完了するまでお待ちください',
             style: TextStyle(color: Color(0xFFAAAAAA), fontSize: 11),
           ),
+        ),
+      ];
+    }
+
+    if (_step == _UpdateStep.permissionRequired) {
+      return [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('後で', style: TextStyle(color: Color(0xFFAAAAAA))),
+        ),
+        ElevatedButton.icon(
+          onPressed: () => _service.openInstallPermissionSettings(),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: const Color(0xFFF20D0D),
+            foregroundColor: Colors.white,
+          ),
+          icon: const Icon(Icons.settings, size: 16),
+          label: const Text('設定を開く'),
         ),
       ];
     }
@@ -214,7 +359,7 @@ class _UpdateDialogState extends State<UpdateDialog> {
         child: const Text('後で', style: TextStyle(color: Color(0xFFAAAAAA))),
       ),
       ElevatedButton(
-        onPressed: _startDownload,
+        onPressed: _onUpdatePressed,
         style: ElevatedButton.styleFrom(
           backgroundColor: const Color(0xFFF20D0D),
           foregroundColor: Colors.white,

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -59,15 +59,24 @@ class _UpdateDialogState extends State<UpdateDialog> with WidgetsBindingObserver
     final granted = await _service.canInstallPackages();
     if (!mounted) return;
     if (granted) {
-      // 許可が付与されたのでダウンロードへ進む
       setState(() => _errorMessage = null);
-      await _startDownload();
+      if (_downloadedPath != null) {
+        // APK は既にダウンロード済み（インストール直前で権限が失われたケース）
+        setState(() => _step = _UpdateStep.readyToInstall);
+      } else {
+        await _startDownload();
+      }
     }
     // まだ未許可なら permissionRequired のまま待機（何もしない）
   }
 
-  /// アップデートボタン押下: 権限を確認してからダウンロード開始。
+  /// アップデートボタン押下: URLと権限を確認してからダウンロード開始。
   Future<void> _onUpdatePressed() async {
+    if (widget.updateInfo.downloadUrl.isEmpty) {
+      setState(() => _errorMessage = 'ダウンロードURLが取得できませんでした。');
+      return;
+    }
+
     final granted = await _service.canInstallPackages();
     if (!mounted) return;
 
@@ -147,11 +156,13 @@ class _UpdateDialogState extends State<UpdateDialog> with WidgetsBindingObserver
               color: const Color(0xFFF20D0D),
             ),
             const SizedBox(width: 8),
-            Text(
-              _step == _UpdateStep.permissionRequired
-                  ? 'インストール許可が必要です'
-                  : 'アップデートがあります',
-              style: const TextStyle(color: Colors.white, fontSize: 16),
+            Flexible(
+              child: Text(
+                _step == _UpdateStep.permissionRequired
+                    ? 'インストール許可が必要です'
+                    : 'アップデートがあります',
+                style: const TextStyle(color: Colors.white, fontSize: 16),
+              ),
             ),
           ],
         ),
@@ -218,16 +229,20 @@ class _UpdateDialogState extends State<UpdateDialog> with WidgetsBindingObserver
             ValueListenableBuilder<double>(
               valueListenable: _service.downloadProgress,
               builder: (_, progress, __) {
+                // progress == -1.0 は Content-Length 不明（不定表示）
+                final isIndeterminate = progress < 0;
                 return Column(
                   children: [
                     LinearProgressIndicator(
-                      value: progress,
+                      value: isIndeterminate ? null : progress,
                       backgroundColor: const Color(0xFF1A1A1A),
                       valueColor: const AlwaysStoppedAnimation(Color(0xFFF20D0D)),
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      '${(progress * 100).toStringAsFixed(0)}%',
+                      isIndeterminate
+                          ? 'ダウンロード中...'
+                          : '${(progress * 100).toStringAsFixed(0)}%',
                       style: const TextStyle(color: Color(0xFFAAAAAA), fontSize: 12),
                     ),
                   ],
@@ -324,7 +339,13 @@ class _UpdateDialogState extends State<UpdateDialog> with WidgetsBindingObserver
           child: const Text('後で', style: TextStyle(color: Color(0xFFAAAAAA))),
         ),
         ElevatedButton.icon(
-          onPressed: () => _service.openInstallPermissionSettings(),
+          onPressed: () async {
+            final opened = await _service.openInstallPermissionSettings();
+            if (!mounted) return;
+            if (!opened) {
+              setState(() => _errorMessage = '設定画面を開けませんでした。手動で設定 → アプリ → SabaTube から許可してください。');
+            }
+          },
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color(0xFFF20D0D),
             foregroundColor: Colors.white,


### PR DESCRIPTION
## 概要

Android のアプリ内アップデート機能において、「提供元不明のアプリ」のインストール許可が付与されていない場合に、許可を促すUIと設定画面への直接遷移を実装しました。あわせてリリースノートの文字化け修正とコードレビューによる品質改善も含みます。

---

## 変更内容

### 1. 「提供元不明のアプリ」許可チェック・誘導機能

**`MainActivity.kt`**
- `MethodChannel` (`win.okasis.sabatube/install_permission`) を追加
- `canInstallPackages`: `PackageManager.canRequestPackageInstalls()` でインストール権限を確認（Android 8.0+、それ未満は常に `true`）
- `openInstallPermissionSettings`: `Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES` + パッケージURIでアプリ専用の許可設定画面へ直接ジャンプ

**`app_update_service.dart`**
- `canInstallPackages()` / `openInstallPermissionSettings()` メソッドを追加

**`update_dialog.dart`**
- `permissionRequired` ステップを追加
  - 「アップデート」ボタン押下時に権限を確認し、未許可なら許可誘導画面へ遷移
  - 「設定を開く」ボタンでアプリ専用設定画面へ直接ジャンプ
  - `WidgetsBindingObserver` で設定画面から戻ったことを検知し、許可済みなら自動でダウンロード開始
  - インストール実行直前にも権限を再確認

### 2. リリースノート文字化け修正

`response.body`（デフォルト Latin-1 解釈）を `utf8.decode(response.bodyBytes)` に変更し、日本語テキストを正しくデコード。

### 3. コードレビューによる品質改善

| 分類 | 修正内容 |
|------|----------|
| 🔴 重要 | `downloadApk` の `IOSink` を `try/finally` で必ずクローズ（ファイルディスクリプタ漏れを防止） |
| 🔴 重要 | ダウンロード失敗時に中途半端なAPKファイルを削除 |
| 🔴 重要 | `_resumeAfterSettings`: APK取得済みの場合は再ダウンロードせず `readyToInstall` へ戻す |
| 🔴 重要 | `downloadUrl` が空文字の場合はエラー表示して処理を中断 |
| 🟡 中程度 | `MainActivity.startActivity` を try-catch で保護し、失敗時は Dart 側にエラーを通知 |
| 🟡 中程度 | Content-Length 不明時にプログレスバーを不定（indeterminate）表示に変更 |
| 🔵 軽微 | タイトルテキストを `Flexible` で囲み、小画面でのオーバーフローを防止 |

---

## 動作フロー

```
アップデート検知
  → UpdateDialog 表示（promptステップ）
  → 「アップデート」ボタン押下
  → 権限チェック
      ├─ 許可済み → ダウンロード開始（従来通り）
      └─ 未許可  → permissionRequiredステップへ
                    ├─「設定を開く」→ アプリ専用許可設定画面へジャンプ
                    └─ アプリに戻ると自動で権限再チェック
                        ├─ 許可済み → 自動でダウンロード開始
                        └─ 未許可  → 画面継続表示
```