### PR TITLE
Implement async loading for total views on profile page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -290,14 +290,19 @@ class _AuthWrapperState extends State<AuthWrapper> {
   Widget build(BuildContext context) {
     // --- 初期化中 ---
     if (!_isInitialized) {
-      return const Scaffold(
+      return Scaffold(
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              Text('初期化中...'),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(20),
+                child: Image.asset('icon.png', width: 100, height: 100),
+              ),
+              const SizedBox(height: 24),
+              const CircularProgressIndicator(),
+              const SizedBox(height: 16),
+              const Text('初期化中...'),
             ],
           ),
         ),
@@ -344,14 +349,19 @@ class _AuthWrapperState extends State<AuthWrapper> {
 
     // --- ギルド検証中 ---
     if (_isVerifyingGuild == true) {
-      return const Scaffold(
+      return Scaffold(
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              Text('Discordサーバーを確認中...'),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(20),
+                child: Image.asset('icon.png', width: 100, height: 100),
+              ),
+              const SizedBox(height: 24),
+              const CircularProgressIndicator(),
+              const SizedBox(height: 16),
+              const Text('Discordサーバーを確認中...'),
             ],
           ),
         ),

--- a/lib/screens/profile/my_page_screen.dart
+++ b/lib/screens/profile/my_page_screen.dart
@@ -48,6 +48,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
   UpdateInfo? _latestUpdateInfo;
 
   bool _isLoading = true;
+  bool _isViewsLoading = true;
 
   @override
   void initState() {
@@ -155,23 +156,32 @@ class _MyPageScreenState extends State<MyPageScreen> {
           CacheService.instance.get<int>(CacheKeys.myPageVideoCount);
       final cachedViews =
           CacheService.instance.get<int>(CacheKeys.myPageTotalViews);
-      if (cachedProfile != null && cachedCount != null && cachedViews != null) {
+      if (cachedProfile != null && cachedCount != null) {
         if (mounted) {
           setState(() {
             _userEmail = user.email;
             _createdAt = DateTime.parse(user.createdAt);
             _userProfile = cachedProfile;
             _totalVideos = cachedCount;
-            _totalViews = cachedViews;
             _isLoading = false;
+            if (cachedViews != null) {
+              _totalViews = cachedViews;
+              _isViewsLoading = false;
+            } else {
+              _isViewsLoading = true;
+            }
           });
         }
+        if (cachedViews != null) return;
+        // 再生数キャッシュなし → 再生数だけ非同期で取得
+        await _fetchAndCacheViews(user.id);
         return;
       }
     }
 
     setState(() {
       _isLoading = true;
+      _isViewsLoading = true;
     });
 
     try {
@@ -191,23 +201,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
       final videoCount = videoUrls.length;
 
-      // Edge Function 経由で合計再生回数を取得（APIキーはサーバーサイドのみ）
-      int totalViews = 0;
-      if (videoUrls.isNotEmpty) {
-        try {
-          final res = await _supabase.functions.invoke(
-            'youtube-views',
-            body: {'videoUrls': videoUrls},
-          );
-          if (res.data != null && res.data['totalViews'] is num) {
-            totalViews = (res.data['totalViews'] as num).toInt();
-          }
-        } catch (e) {
-          debugPrint('⚠️ Failed to fetch view counts: $e');
-        }
-      }
-
-      // キャッシュに保存
+      // プロフィール・投稿数をキャッシュに保存
       if (profile != null) {
         CacheService.instance.set<UserProfile>(
           CacheKeys.myPageProfile,
@@ -218,29 +212,80 @@ class _MyPageScreenState extends State<MyPageScreen> {
         CacheKeys.myPageVideoCount,
         videoCount,
       );
-      // 再生回数は翌日の日本時間 0:00 まで有効
-      CacheService.instance.set<int>(
-        CacheKeys.myPageTotalViews,
-        totalViews,
-        ttl: _ttlUntilJstMidnight(),
-      );
 
+      // フェーズ1完了: ページを即座に表示（総再生数はまだ読み込み中）
       if (mounted) {
         setState(() {
           _userEmail = user.email;
           _createdAt = DateTime.parse(user.createdAt);
           _userProfile = profile;
           _totalVideos = videoCount;
-          _totalViews = totalViews;
           _isLoading = false;
+          // _isViewsLoading は true のまま
         });
       }
+
+      // フェーズ2: 総再生数を非同期で取得
+      await _fetchAndCacheViews(user.id, videoUrls: videoUrls);
     } catch (e) {
       if (mounted) {
         setState(() {
           _isLoading = false;
+          _isViewsLoading = false;
         });
       }
+    }
+  }
+
+  /// Edge Function 経由で総再生数を取得してキャッシュに保存する
+  Future<void> _fetchAndCacheViews(
+    String userId, {
+    List<String>? videoUrls,
+  }) async {
+    // videoUrls が渡されていない場合は再取得
+    List<String> urls;
+    if (videoUrls != null) {
+      urls = videoUrls;
+    } else {
+      try {
+        final res =
+            await _supabase.from('videos').select('url').eq('user_id', userId);
+        urls = (res as List)
+            .map((v) => v['url'] as String? ?? '')
+            .where((url) => url.isNotEmpty)
+            .toList();
+      } catch (e) {
+        urls = [];
+      }
+    }
+
+    int totalViews = 0;
+    if (urls.isNotEmpty) {
+      try {
+        final res = await _supabase.functions.invoke(
+          'youtube-views',
+          body: {'videoUrls': urls},
+        );
+        if (res.data != null && res.data['totalViews'] is num) {
+          totalViews = (res.data['totalViews'] as num).toInt();
+        }
+      } catch (e) {
+        debugPrint('⚠️ Failed to fetch view counts: $e');
+      }
+    }
+
+    // 再生回数は翌日の日本時間 0:00 まで有効
+    CacheService.instance.set<int>(
+      CacheKeys.myPageTotalViews,
+      totalViews,
+      ttl: _ttlUntilJstMidnight(),
+    );
+
+    if (mounted) {
+      setState(() {
+        _totalViews = totalViews;
+        _isViewsLoading = false;
+      });
     }
   }
 
@@ -391,6 +436,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     required String label,
     required String value,
     required Color color,
+    bool isLoading = false,
   }) {
     return Container(
       padding: const EdgeInsets.all(16),
@@ -409,14 +455,23 @@ class _MyPageScreenState extends State<MyPageScreen> {
         children: [
           Icon(icon, color: color, size: 32),
           const SizedBox(height: 8),
-          Text(
-            value,
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
-          ),
+          isLoading
+              ? SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: color,
+                  ),
+                )
+              : Text(
+                  value,
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: color,
+                  ),
+                ),
           const SizedBox(height: 4),
           Text(
             label,
@@ -820,7 +875,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
               children: [
                 _buildWideStatItem(context, '動画投稿数', '$_totalVideos'),
                 _buildWideStatDivider(context),
-                _buildWideStatItem(context, '総再生数', '$_totalViews'),
+                _buildWideStatItem(context, '総再生数', '$_totalViews',
+                    isLoading: _isViewsLoading),
                 _buildWideStatDivider(context),
                 _buildWideStatItem(context, 'いいね', '$_totalLikes'),
               ],
@@ -831,7 +887,12 @@ class _MyPageScreenState extends State<MyPageScreen> {
     );
   }
 
-  Widget _buildWideStatItem(BuildContext context, String label, String value) {
+  Widget _buildWideStatItem(
+    BuildContext context,
+    String label,
+    String value, {
+    bool isLoading = false,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Column(
@@ -845,13 +906,19 @@ class _MyPageScreenState extends State<MyPageScreen> {
             ),
           ),
           const SizedBox(height: 4),
-          Text(
-            value,
-            style: const TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+          isLoading
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(
+                  value,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
         ],
       ),
     );
@@ -1319,6 +1386,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                         label: '総再生数',
                         value: '$_totalViews',
                         color: Colors.orange,
+                        isLoading: _isViewsLoading,
                       ),
                     ),
                     const SizedBox(width: 12),


### PR DESCRIPTION
## Summary
Refactored the profile page to load total video views asynchronously, allowing the page to render immediately with cached data while views are fetched in the background. This improves perceived performance and user experience.

## Key Changes

### Profile Page (`my_page_screen.dart`)
- Added `_isViewsLoading` state variable to track views loading status independently from overall page loading
- Extracted views fetching logic into a new `_fetchAndCacheViews()` method that can be called independently
- Implemented two-phase loading:
  - **Phase 1**: Display profile, video count, and cached data immediately
  - **Phase 2**: Fetch and cache total views asynchronously in the background
- Updated cache logic to allow profile and video count to load without requiring cached views
- Modified `_buildStatItem()` and `_buildWideStatItem()` widgets to display loading spinners when views are being fetched
- Updated all stat item calls to pass `isLoading` parameter for views display

### Initialization Screens (`main.dart`)
- Enhanced loading screens with app icon display during initialization and guild verification
- Added rounded corners to icon using `ClipRRect`
- Improved visual hierarchy with better spacing and consistent styling
- Added const modifiers for better performance

## Implementation Details
- Views are fetched via Edge Function after profile data is cached
- Views cache has a TTL until the next day at JST midnight
- If views are already cached, they're displayed immediately without additional loading
- The `_fetchAndCacheViews()` method can accept pre-fetched video URLs or re-fetch them from the database
- Loading indicators appear only for the views stat while other stats display normally

https://claude.ai/code/session_018e9E7sG6PyphErXRWgb6TF