### PR TITLE
fix: Discord認証エラーの診断情報表示とガイド更新

### DIFF
--- a/DISCORD_SETUP_GUIDE.md
+++ b/DISCORD_SETUP_GUIDE.md
@@ -84,6 +84,32 @@ https://vqvyyyqhtbgxtmknuigf.supabase.co/auth/v1/callback
 
 ## トラブルシューティング
 
+### 「Discord認証の設定を確認してください」/ `Unable to exchange external code` エラーが発生する
+
+このエラーはSupabaseがDiscordのトークン交換に失敗した場合に発生します。以下を順番に確認してください：
+
+**① Discord Developer Portalのリダイレクト URI を確認**
+
+Discord Developer Portal (https://discord.com/developers/applications) を開き、
+該当アプリの **OAuth2** > **Redirects** に以下が登録されていることを確認：
+
+```
+https://<your-supabase-project-ref>.supabase.co/auth/v1/callback
+```
+
+> ⚠️ 正確なSupabaseプロジェクトURLはSupabaseダッシュボードの **Settings** > **API** で確認できます。
+> アプリのエラー画面にも正確なURLが表示されます。
+
+**② Supabase の Discord プロバイダー設定を確認**
+
+Supabaseダッシュボード > **Authentication** > **Providers** > **Discord** を開き：
+- ✅ **Enabled**: ON になっているか
+- **Client ID**: Discord Developer Portalの「OAuth2 > Client ID」と一致しているか
+- **Client Secret**: Discord Developer Portalの「OAuth2 > Client Secret」と一致しているか
+  - Secretは再生成すると古い値が無効になります。再生成した場合はSupabaseも更新が必要です。
+
+---
+
 ### 「指定のDiscordサーバーに参加していないため、ログインできません」と表示される
 - Discord サーバー（Guild ID: `1195727435333894144`）に参加していることを確認
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -421,6 +421,13 @@ class _AuthWrapperState extends State<AuthWrapper> {
 
         // エラーハンドリング
         if (snapshot.hasError) {
+          final errorStr = snapshot.error.toString();
+          final isDiscordExchangeError = errorStr.contains('Unable to exchange external code') ||
+              (errorStr.contains('server_error') && errorStr.contains('unexpected_failure'));
+          final supabaseCallbackUrl = isDiscordExchangeError
+              ? '${SupabaseService.instance.client.supabaseUrl}/auth/v1/callback'
+              : null;
+
           return Scaffold(
             body: Center(
               child: Padding(
@@ -435,13 +442,20 @@ class _AuthWrapperState extends State<AuthWrapper> {
                     ),
                     const SizedBox(height: 16),
                     Text(
-                      '認証エラーが発生しました。\n${snapshot.error}',
+                      isDiscordExchangeError
+                          ? 'Discord認証の設定を確認してください。\n\n以下のURLがDiscord Developer PortalのOAuth2リダイレクトURIに登録されているか確認してください：\n\n$supabaseCallbackUrl\n\nまたはSupabaseのDiscordプロバイダー設定（Client ID/Secret）を確認してください。'
+                          : '認証エラーが発生しました。\n$errorStr',
                       textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 13),
                     ),
                     const SizedBox(height: 24),
                     ElevatedButton(
                       onPressed: () {
-                        setState(() {});
+                        setState(() {
+                          _guildVerified = false;
+                          _isVerifyingGuild = null;
+                          _guildErrorMessage = null;
+                        });
                       },
                       child: const Text('再読み込み'),
                     ),

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -81,19 +81,10 @@ class SupabaseService {
       }
 
       // Supabaseの初期化
-      // authFlowType: implicit を使用する理由:
-      // PKCEフロー（デフォルト）はlocalStorageにcode_verifierを保存するが、
-      // モバイルブラウザではOAuth中に別アプリへ切り替えた際にlocalStorageが
-      // クリアされ、"Unable to exchange external code"エラーが発生する。
-      // implicitフローはトークンをURLハッシュで直接返すため、
-      // localStorageの永続化が不要でモバイルブラウザでも安定して動作する。
       await Supabase.initialize(
         url: supabaseUrl,
         anonKey: supabaseAnonKey,
         debug: kDebugMode,
-        authOptions: const FlutterAuthClientOptions(
-          authFlowType: AuthFlowType.implicit,
-        ),
       );
 
       _client = Supabase.instance.client;


### PR DESCRIPTION
## 問題の調査結果

`Unable to exchange external code: server_error` エラーの根本原因は **クライアントコードではなく、Discord/Supabaseのサーバーサイド設定の問題**です。

### エラーの発生箇所

```
SupabaseサーバーがDiscordのトークンエンドポイントを呼び出した際に失敗
```

OAuthフローの流れ：
1. ✅ Discordの認証ページが表示される（ユーザーが承認）
2. ✅ Discordがコード（`Ak8e...`, `8Hc5...`）をSupabaseに返す
3. ❌ **Supabaseがそのコードでディスコードのトークンエンドポイントを呼び出すと失敗**
4. SupabaseがFlutterアプリに `server_error` を返す

この問題は `authFlowType` (PKCE/Implicit) とは完全に無関係です。

### 主な原因

| 原因 | 確認箇所 |
|------|---------|
| Discord Developer PortalにSupabaseのコールバックURLが未登録 | Discord Developer Portal > OAuth2 > Redirects |
| SupabaseのDiscord Client Secretが古い/不正 | Supabase > Authentication > Providers > Discord |

---

## 変更内容

### 1. `lib/main.dart` — エラー画面の改善

`Unable to exchange external code` エラー発生時に、**実際のSupabaseコールバックURLをエラー画面に表示**するように変更。

ユーザーは表示されたURLをDiscord Developer Portalに登録されているかどうかをその場で確認できます。

```
Discord認証の設定を確認してください。

以下のURLがDiscord Developer PortalのOAuth2リダイレクトURIに
登録されているか確認してください：

https://xxxxxx.supabase.co/auth/v1/callback

またはSupabaseのDiscordプロバイダー設定（Client ID/Secret）を確認してください。
```

また、再読み込みボタン押下時に状態が正しくリセットされるよう修正。

### 2. `lib/services/supabase_service.dart` — 誤修正の取り消し

前のPRで追加した `authFlowType: AuthFlowType.implicit` を取り消し。このエラーの原因ではなかったため。

### 3. `DISCORD_SETUP_GUIDE.md` — トラブルシューティング追記

このエラーパターンに対する具体的な対処手順を追加：
- Discord Developer Portal のリダイレクトURI確認手順
- Supabase Discord プロバイダー設定（Client ID/Secret）の確認手順
- Client Secretを再生成した際の更新が必要であることの注意書き

---

## 修正に必要な手動対応

このPRのコードをデプロイした後、エラー画面に表示されるURLを元に以下を確認してください：

1. **Discord Developer Portal** > アプリ > OAuth2 > Redirects
   - 表示されたSupabaseコールバックURL（`https://xxx.supabase.co/auth/v1/callback`）が登録されているか確認・追加

2. **Supabase** > Authentication > Providers > Discord
   - Client IDとClient SecretがDiscord Developer Portalの値と一致しているか確認
   - Secret再生成した場合は必ず更新

https://claude.ai/code/session_013MVE2hcUW93QdCxKiwXvYt

---
_Generated by [Claude Code](https://claude.ai/code/session_013MVE2hcUW93QdCxKiwXvYt)_