### PR TITLE
fix: ビルドエラー修正 (supabaseUrl) + Discord認証エラー診断表示

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -425,7 +425,7 @@ class _AuthWrapperState extends State<AuthWrapper> {
           final isDiscordExchangeError = errorStr.contains('Unable to exchange external code') ||
               (errorStr.contains('server_error') && errorStr.contains('unexpected_failure'));
           final supabaseCallbackUrl = isDiscordExchangeError
-              ? '${SupabaseService.instance.client.supabaseUrl}/auth/v1/callback'
+              ? '${SupabaseService.supabaseUrl}/auth/v1/callback'
               : null;
 
           return Scaffold(

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -10,6 +10,9 @@ class SupabaseService {
   static SupabaseService? _instance;
   static SupabaseClient? _client;
   static String? _sharedPassword;
+  static String? _supabaseUrl;
+
+  static String? get supabaseUrl => _supabaseUrl;
 
   SupabaseService._();
 
@@ -88,6 +91,7 @@ class SupabaseService {
       );
 
       _client = Supabase.instance.client;
+      _supabaseUrl = supabaseUrl;
 
       if (kDebugMode) {
         debugPrint('✅ Supabase initialized successfully');


### PR DESCRIPTION
## 修正内容

### ビルドエラーの修正

前のPRで発生したビルドエラーを修正：

```
Error: The getter 'supabaseUrl' isn't defined for the type 'SupabaseClient'.
```

`supabase-2.10.2` の `SupabaseClient` には `supabaseUrl` プロパティが存在しないため、`SupabaseService` 側で初期化時のURLを静的フィールドに保持し、ゲッターで公開する形に変更。

```dart
// supabase_service.dart
static String? _supabaseUrl;
static String? get supabaseUrl => _supabaseUrl;

// initialize()内
_supabaseUrl = supabaseUrl;  // dotenvから読んだURLを保存

// main.dart
'${SupabaseService.supabaseUrl}/auth/v1/callback'
```

### Discord認証エラーの診断表示

`Unable to exchange external code` エラー（Supabase→Discordのサーバーサイドトークン交換失敗）発生時に、実際のSupabaseコールバックURLをエラー画面に表示。

ユーザーは表示されたURLをDiscord Developer Portalの設定と照合できます。

## 根本原因について

このエラーはコードの問題ではなく**設定の問題**です：

- **Discord Developer Portal** → OAuth2 → Redirects に `https://{project}.supabase.co/auth/v1/callback` が未登録
- または **Supabase** → Authentication → Providers → Discord の Client Secret が古い/不一致

デプロイ後、ログイン失敗時のエラー画面に正確なコールバックURLが表示されるので、Discord Developer Portalの設定と照合してください。

https://claude.ai/code/session_013MVE2hcUW93QdCxKiwXvYt

---
_Generated by [Claude Code](https://claude.ai/code/session_013MVE2hcUW93QdCxKiwXvYt)_